### PR TITLE
Hi! I think there was a bug on Router.php :)

### DIFF
--- a/flight/net/Router.php
+++ b/flight/net/Router.php
@@ -80,7 +80,7 @@ class Router {
         $ids = array();
 
         // Build the regex for matching
-        $regex = '/^'.implode('\/', array_map(
+        $regex = implode('\/', array_map(
             function($str) use (&$ids){
                 if ($str == '*') {
                     $str = '(.*)';


### PR DESCRIPTION
The old regex, used to route  /love and /love/ when was defined Flight::route("/love", function(){})
