### PR TITLE
Support for calling methods on an object instance.

### DIFF
--- a/flight/core/Dispatcher.php
+++ b/flight/core/Dispatcher.php
@@ -176,19 +176,21 @@ class Dispatcher {
     public static function invokeMethod($func, array &$params = array()) {
         list($class, $method) = $func;
 
+		$instance = is_object($class);
+		
         switch (count($params)) {
             case 0:
-                return $class::$method();
+                return ($instance) ? $class->$method() : $class::$method();
             case 1:
-                return $class::$method($params[0]);
+                return ($instance) ? $class->$method($params[0]) : $class::$method($params[0]);
             case 2:
-                return $class::$method($params[0], $params[1]);
+                return ($instance) ? $class->$method($params[0], $params[1]) : $class::$method($params[0], $params[1]);
             case 3:
-                return $class::$method($params[0], $params[1], $params[2]);
+                return ($instance) ? $class->$method($params[0], $params[1], $params[2]) : $class::$method($params[0], $params[1], $params[2]);
             case 4:
-                return $class::$method($params[0], $params[1], $params[2], $params[3]);
+                return ($instance) ? $class->$method($params[0], $params[1], $params[2], $params[3]) : $class::$method($params[0], $params[1], $params[2], $params[3]);
             case 5:
-                return $class::$method($params[0], $params[1], $params[2], $params[3], $params[4]);
+                return ($instance) ? $class->$method($params[0], $params[1], $params[2], $params[3], $params[4]) : $class::$method($params[0], $params[1], $params[2], $params[3], $params[4]);
             default:
                 return call_user_func_array($func, $params);
         }


### PR DESCRIPTION
Hello,

While using your framework I noticed there currently isn't any way to call non-static methods on objects. Since I needed this functionality for a project I was working on, I decided implemented it myself and though I may as well send in a pull request with it :)

My change basically adds a load of extra conditionals in to the invokeMethod in the Dispatcher, which check whether or not $class is an instance and if it is call $class->$method instead of $class::$method. 

I'd originally just added a if(is_object($class)) call_user_func_array($func, $params); Although decided to follow your style more closely due to the speed impact of calling call_user_func_array unnecessarily.

Hopefully the code is all okay (and i haven't managed to overlook any obvious ways of doing this already within the framework),
Thanks,
Carl

Example usage:

$obj = new Obj();
Flight::route('/myMethod', array($obj,'myMethod'));
