### PR TITLE
Fixed muted error in Loader

### DIFF
--- a/flight/core/Loader.php
+++ b/flight/core/Loader.php
@@ -175,7 +175,8 @@ class Loader {
         }
 
         // Allow other autoloaders to run before raising an error
-        $loader = array_pop(spl_autoload_functions());
+        $loaders = spl_autoload_functions();
+        $loader  = array_pop($loaders);
         if (is_array($loader) && $loader[0] == __CLASS__ && $loader[1] == __FUNCTION__) {
             throw new Exception('Unable to load file: '.$class_file);
         }


### PR DESCRIPTION
This error appear only when default error handler is rewriten or custom error handler assigned.

Despite that there is no error in normal occasion, IMHO have any error in code is bad even if you don't see one.

Also it is strange to ignore some types of errors in error handler. Maybe configuration could regulate it - `flight.debug` or `flight.production` for example?

P.S. Sorry for my english.
