### PR TITLE
using basename instead of testing with strpos.

### DIFF
--- a/flight/template/View.php
+++ b/flight/template/View.php
@@ -143,7 +143,7 @@ class View {
      * @return string Template file location
      */
     public function getTemplate($file) {
-        return $this->path.'/'.((substr($file, -4) == '.php') ? $file : $file.'.php');
+        return $this->path.'/'.basename($file, '.php').'.php';
     }
 
     /**


### PR DESCRIPTION
I have been tearing flight apart and I like it a lot, I noticed it was testing

`((substr($file, -4) == '.php') ? $file : $file.'.php')`

it is a bit more clear IMO to say

`basename($file, '.php').'.php'`

which accomplishes the same thing pretty much.

also have you considered using `getenv()` instead of testing `isset()` on `$_SERVER` in a lot of places? It returns false or the correct value of most of the stuff in the `$_SERVER` array, so you can do for example `getenv('SERVER_PROTOCOL') ?: 'HTTP/1.1'`
