### PR TITLE
Fixed variable name typo in template/layout example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ It is common for websites to have a single layout template file with interchangi
 
 ```php
 Flight::render('header', array('heading' => 'Hello'), 'header_content');
-Flight::render('body', array('message' => 'World'), 'body_content');
+Flight::render('body', array('body' => 'World'), 'body_content');
 ```
 
 Your view will then have saved variables called `header_content` and `body_content`. You can then render your layout by doing:


### PR DESCRIPTION
This is also a typo on the http://flightphp.com/learn page.
