### PR TITLE
Removing redundant code that repeats actions for different number of parameters passed

### DIFF
--- a/flight/core/Dispatcher.php
+++ b/flight/core/Dispatcher.php
@@ -152,22 +152,7 @@ class Dispatcher {
      * @return mixed Function results
      */
     public static function callFunction($func, array &$params = array()) {
-        switch (count($params)) {
-            case 0:
-                return $func();
-            case 1:
-                return $func($params[0]);
-            case 2:
-                return $func($params[0], $params[1]);
-            case 3:
-                return $func($params[0], $params[1], $params[2]);
-            case 4:
-                return $func($params[0], $params[1], $params[2], $params[3]);
-            case 5:
-                return $func($params[0], $params[1], $params[2], $params[3], $params[4]);
-            default:
-                return call_user_func_array($func, $params);
-        }
+        return call_user_func_array($func, $params);
     }
 
     /**
@@ -179,37 +164,8 @@ class Dispatcher {
      */
     public static function invokeMethod($func, array &$params = array()) {
         list($class, $method) = $func;
-
 		$instance = is_object($class);
-		
-        switch (count($params)) {
-            case 0:
-                return ($instance) ?
-                    $class->$method() :
-                    $class::$method();
-            case 1:
-                return ($instance) ?
-                    $class->$method($params[0]) :
-                    $class::$method($params[0]);
-            case 2:
-                return ($instance) ?
-                    $class->$method($params[0], $params[1]) :
-                    $class::$method($params[0], $params[1]);
-            case 3:
-                return ($instance) ?
-                    $class->$method($params[0], $params[1], $params[2]) :
-                    $class::$method($params[0], $params[1], $params[2]);
-            case 4:
-                return ($instance) ?
-                    $class->$method($params[0], $params[1], $params[2], $params[3]) :
-                    $class::$method($params[0], $params[1], $params[2], $params[3]);
-            case 5:
-                return ($instance) ?
-                    $class->$method($params[0], $params[1], $params[2], $params[3], $params[4]) :
-                    $class::$method($params[0], $params[1], $params[2], $params[3], $params[4]);
-            default:
-                return call_user_func_array($func, $params);
-        }
+        return call_user_func_array($func, $params);
     }
 
     /**

--- a/flight/core/Loader.php
+++ b/flight/core/Loader.php
@@ -111,23 +111,8 @@ class Loader {
      * @return object Class instance
      */
     public function newInstance($class, array $params = array()) {
-        switch (count($params)) {
-            case 0:
-                return new $class();
-            case 1:
-                return new $class($params[0]);
-            case 2:
-                return new $class($params[0], $params[1]);
-            case 3:
-                return new $class($params[0], $params[1], $params[2]);
-            case 4:
-                return new $class($params[0], $params[1], $params[2], $params[3]);
-            case 5:
-                return new $class($params[0], $params[1], $params[2], $params[3], $params[4]);
-            default:
-                $refClass = new \ReflectionClass($class);
-                return $refClass->newInstanceArgs($params);
-        }
+        $refClass = new \ReflectionClass($class);
+        return $refClass->newInstanceArgs($params);
     }
 
     /**


### PR DESCRIPTION
On several places the `Dispatcher` and `Loader` methods repeat the same action for different number of parameters passed. Finally, default handler works for any number of parameters.

This code seems to be redundant as the framework works as expected without those lines.

Have a look please and merge if works for you as well.

Thanks.
