### PR TITLE
Fix composer autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mikecao/flight",
     "autoload": {
-        "files": ["flight/Flight.php"]
+        "files": ["flight/autoload.php"]
     },
     "license": "MIT",
     "description": "Flight is a fast, simple, extensible framework for PHP. Flight enables you to quickly and easily build RESTful web applications.",

--- a/flight/Flight.php
+++ b/flight/Flight.php
@@ -6,8 +6,8 @@
  * @license     http://www.opensource.org/licenses/mit-license.php
  */
 
-include __DIR__.'/core/Loader.php';
-include __DIR__.'/core/Dispatcher.php';
+require_once __DIR__.'/core/Loader.php';
+require_once __DIR__.'/core/Dispatcher.php';
 
 /**
  * The Flight class represents the framework itself. It is responsible

--- a/flight/autoload.php
+++ b/flight/autoload.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Flight: An extensible micro-framework.
+ *
+ * @copyright   Copyright (c) 2011, Mike Cao <mike@mikecao.com>
+ * @license     http://www.opensource.org/licenses/mit-license.php
+ */
+
+/**
+ * provides composer autoloader mechanism 
+ */
+
 include __DIR__.'/core/Loader.php';
 
 $loader = new \flight\core\Loader();


### PR DESCRIPTION
This patch fixes composer autoloader issue, which is calling Flight::init() before any try to access Flight classes.
This patch postpones init() call to first Flight class access. (does not affect normal Flight.php inclusion)
