### PR TITLE
JSONP support

### DIFF
--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -447,7 +447,7 @@ class Engine {
      */
     public function _jsonp($data) {
         // Get the callback value (eg '?jsonp=my_function') and pad the output
-        $callback = \Flight::request()->query[ $this->get('flight.jsonp.callback') ];
+        $callback = $this->request()->query[ $this->get('flight.jsonp.callback') ];
         $this->response()
             ->status(200)
             ->header('Content-Type', 'application/javascript')

--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -94,7 +94,7 @@ class Engine {
         // Register framework methods
         $methods = array(
             'start','stop','route','halt','error','notFound',
-            'render','redirect','etag','lastModified','json'
+            'render','redirect','etag','lastModified','json','jsonp'
         );
         foreach ($methods as $name) {
             $this->dispatcher->set($name, array($this, '_'.$name));
@@ -105,6 +105,7 @@ class Engine {
         $this->set('flight.handle_errors', true);
         $this->set('flight.log_errors', false);
         $this->set('flight.views.path', './views');
+        $this->set('flight.jsonp.callback', 'jsonp');
 
         $initialized = true;
     }
@@ -436,6 +437,21 @@ class Engine {
             ->status(200)
             ->header('Content-Type', 'application/json')
             ->write(json_encode($data))
+            ->send();
+    }
+	
+    /**
+     * Sends a JSONP response.
+     *
+     * @param mixed $data Data to JSON encode
+     */
+    public function _jsonp($data) {
+		// Get the callback value (eg '?jsonp=my_function') and pad the output
+		$callback = \Flight::request()->query[ $this->get('flight.jsonp.callback') ];
+        $this->response()
+            ->status(200)
+            ->header('Content-Type', 'application/javascript')
+            ->write($callback.'('.json_encode($data).');')
             ->send();
     }
 

--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -446,8 +446,8 @@ class Engine {
      * @param mixed $data Data to JSON encode
      */
     public function _jsonp($data) {
-		// Get the callback value (eg '?jsonp=my_function') and pad the output
-		$callback = \Flight::request()->query[ $this->get('flight.jsonp.callback') ];
+        // Get the callback value (eg '?jsonp=my_function') and pad the output
+        $callback = \Flight::request()->query[ $this->get('flight.jsonp.callback') ];
         $this->response()
             ->status(200)
             ->header('Content-Type', 'application/javascript')


### PR DESCRIPTION
Hi

Thanks a zillion for this neat little framework. I'm using it to develop api.yourls.org, it's lovely and has everything needed to roll out APIs :-)

I would like it to support JSONP out of the box, would you be interested in a pull request?

My implementation works this way:
- new default setting to set the callback name: `flight.jsonp.callback`
- new function `_jsonp()` outputting JSON padded with the callback value (eg `/route/?jsonp=foo` will output `foo(...JSON response here...);`

Thanks for your time!
