### PR TITLE
Simplify output buffering code

### DIFF
--- a/flight/template/View.php
+++ b/flight/template/View.php
@@ -122,9 +122,7 @@ class View {
         ob_start();
 
         $this->render($file, $data);
-        $output = ob_get_contents();
-
-        ob_end_clean();
+        $output = ob_get_clean();
 
         return $output;
     }


### PR DESCRIPTION
No need to use both ob_get_contents() and ob_end_clean() when you can just use ob_get_clean().
