### PR TITLE
Fixed problem with Request Json array

### DIFF
--- a/flight/net/Request.php
+++ b/flight/net/Request.php
@@ -187,8 +187,11 @@ class Request {
 
         if (strpos($this->type, 'application/json') === 0 && $this->body != '') {
             $this->json = json_decode($this->body, true);
-			$this->json = new Collection($this->json);
+        } else {
+            $this->json = array();
         }
+		
+        $this->json = new Collection($this->json);
 		
     }
 

--- a/flight/net/Request.php
+++ b/flight/net/Request.php
@@ -185,9 +185,11 @@ class Request {
             $this->query->setData($_GET);
         }
 
-        if ($this->type == 'application/json' && $this->body != '') {
+        if (strpos($this->type, 'application/json') === 0 && $this->body != '') {
             $this->json = json_decode($this->body, true);
+			$this->json = new Collection($this->json);
         }
+		
     }
 
     /**


### PR DESCRIPTION
Using the Flight Framework with AngularJS, I send POST data as JSON in the request body, my problem was that the browser sent the following content type : "application/json;charset=utf-8".

When this was interpreted by the Request handler, it didn't get put into the Flight::request()->json variable because the content type didn't exactly match " application/json". I have fixed this and now also send the json data through the Collection system to enable users to access as an object or an array, as they desire.
