### PR TITLE
added new setting "add_route_obj"

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,7 @@ The following is a list of all the available configuration settings:
     flight.handle_errors - Allow Flight to handle all errors internally. (default: true)
     flight.log_errors - Log errors to the web server's error log file. (default: false)
     flight.views.path - Directory containing view template files. (default: ./views)
+    flight.add_route_obj - Add routing object to all callbacks as last parameter (default: true)
 
 # Framework Methods
 

--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -106,6 +106,7 @@ class Engine {
         $this->set('flight.handle_errors', true);
         $this->set('flight.log_errors', false);
         $this->set('flight.views.path', './views');
+        $this->set('flight.add_route_obj', true);
 
         $initialized = true;
     }
@@ -303,7 +304,9 @@ class Engine {
         // Route the request
         while ($route = $router->route($request)) {
             $params = array_values($route->params);
-            array_push($params, $route);
+            if ($this->get('flight.add_route_obj')) {
+            	array_push($params, $route);
+            }
 
             $continue = $this->dispatcher->execute(
                 $route->callback,


### PR DESCRIPTION
To be able to use the same callback multiple times (with default values for parameters) like this:

```
Flight::route('GET /', array('\Application\Controller\Section', 'showSection'));
Flight::route('GET /section/@name', array('\Application\Controller\Section', 'showSection'));
Flight::route('GET /section/@name/@subname', array('\Application\Controller\Section', 'showSection'));
```

It would be nice to restore the old behavior of flightphp to disable auto append of Route object as last parameter to every route callback. 

By setting 'flight.add_route_obj' to false this is possible with this patch.
