### PR TITLE
Add support for getting request status

### DIFF
--- a/flight/net/Response.php
+++ b/flight/net/Response.php
@@ -83,7 +83,11 @@ class Response {
      * @return object Self reference
      * @throws \Exception If invalid status code
      */
-    public function status($code) {
+    public function status($code = null) {
+        if ($code === null) {
+            return $this->status;
+        }
+
         if (array_key_exists($code, self::$codes)) {
             $this->status = $code;
         }

--- a/flight/net/Response.php
+++ b/flight/net/Response.php
@@ -66,6 +66,7 @@ class Response {
         415 => 'Unsupported Media Type',
         416 => 'Requested Range Not Satisfiable',
         417 => 'Expectation Failed',
+        418 => 'Permanent Redirect',
 
         500 => 'Internal Server Error',
         501 => 'Not Implemented',


### PR DESCRIPTION
For some applications it's useful to get the response status code, this PR adds support for getting it by calling `Flight::response()->status()` with no arguments. I've also added support for the experimental HTTP response code 408, "Permanent Redirect"
