### PR TITLE
PUT only allows php://input to be read once

### DIFF
--- a/flight/net/Request.php
+++ b/flight/net/Request.php
@@ -121,11 +121,6 @@ class Request {
     public $proxy_ip;
 
     /**
-     * @var mixed Data from the request body
-     */
-    protected static $body;
-
-    /**
      * Constructor.
      *
      * @param array $config Request configuration
@@ -201,20 +196,20 @@ class Request {
      *
      * @return string Raw HTTP request body
      */
-    public static function getBody()
-    {
-        if (!is_null(self::$body)) {
-            return self::$body;
+    public static function getBody() {
+        static $body;
+
+        if (!is_null($body)) {
+            return $body;
         }
 
-        $body = '';
         $method = self::getMethod();
 
         if ($method == 'POST' || $method == 'PUT') {
             $body = file_get_contents('php://input');
         }
 
-        return self::$body = $body;
+        return $body;
     }
 
     /**

--- a/flight/net/Request.php
+++ b/flight/net/Request.php
@@ -121,6 +121,11 @@ class Request {
     public $proxy_ip;
 
     /**
+     * @var mixed Data from the request body
+     */
+    protected static $body;
+
+    /**
      * Constructor.
      *
      * @param array $config Request configuration
@@ -198,13 +203,18 @@ class Request {
      */
     public static function getBody()
     {
+        if (!is_null(self::$body)) {
+            return self::$body;
+        }
+
+        $body = '';
         $method = self::getMethod();
 
         if ($method == 'POST' || $method == 'PUT') {
-            return file_get_contents('php://input');
+            $body = file_get_contents('php://input');
         }
 
-        return '';
+        return self::$body = $body;
     }
 
     /**


### PR DESCRIPTION
On PUT requests, the contents of the input stream can only be read once. That means `Request::getBody()` can't be called multiple times. Is this a reasonable workaround?
