### PR TITLE
Using multiple template paths

### DIFF
--- a/flight/template/View.php
+++ b/flight/template/View.php
@@ -154,7 +154,13 @@ class View {
         if ((substr($file, -4) != '.php')) {
             $file .= '.php';
         }
-        return $this->path.'/'.$file;
+        if ((substr($file, 0, 1) == '/')) {
+            return $file;
+        }
+        else
+        {
+            return $this->path.'/'.$file;
+        }
     }
 
     /**


### PR DESCRIPTION
I want to use more template directory's along with the multiple flight.views.path during execution of the script. So want to be able to change it on the fly, during execution. And I want the extra template directory's to be outside of the normal flight.views.path.
I tried a lot of ways without changing the View.php but this change is simpel and works for me.
This way I can easily do:
Flight::render(TPL_PATH.'hello', ['name'=>'Bob'], 'header_content');
