### PR TITLE
Added list of methods for autocomplete

### DIFF
--- a/flight/Flight.php
+++ b/flight/Flight.php
@@ -8,6 +8,28 @@
 
 /**
  * The Flight class is a static representation of the framework.
+ * 
+ * @method  static void map($name, $callback) Creates a custom framework method.
+ * @method  static void register($name, $class, array $params = array(), $callback = null) Registers a class to a framework method.
+ * @method  static void before($name, $callback) Adds a filter before a framework method.
+ * @method  static void after($name, $callback) Adds a filter after a framework method.
+ * @method  static void path($path) Adds a path for autoloading classes.
+ * @method  static void get($key) Gets a variable.
+ * @method  static void set($key, $value) Sets a variable.
+ * @method  static void has($key) Checks if a variable is set.
+ * @method  static void clear($key = null) Clears a variable.
+ * @method  static void start() Starts the framework.
+ * @method  static void stop() Stops the framework and sends a response.
+ * @method  static void halt($code = 200, $message = '') Stop the framework with an optional status code and message.
+ * @method  static void route($pattern, $callback) Maps a URL pattern to a callback.
+ * @method  static void redirect($url, $code = 303) Redirects to another URL.
+ * @method  static void render($file, array $data = null, $key = null) Renders a template file.
+ * @method  static void error($exception) Sends an HTTP 500 response.
+ * @method  static void notFound() Sends an HTTP 404 response.
+ * @method  static void etag($id, $type = 'strong') Performs ETag HTTP caching.
+ * @method  static void lastModified($time) Performs last modified HTTP caching.
+ * @method  static void json($data, $code = 200, $encode = true) Sends a JSON response.
+ * @method  static void jsonp($data, $param = 'jsonp', $code = 200, $encode = true) Sends a JSONP response.
  */
 class Flight {
     /**


### PR DESCRIPTION
Added list of available methods to the PHPDoc section of `Flight` class. Inspired by suggestion: http://stackoverflow.com/a/26628288/1363799

Autocomplete was tested in PHPStorm 8.0.1:

![flight-autocomplete](https://cloud.githubusercontent.com/assets/1920639/4838719/f0f75f8c-5fef-11e4-9c47-997a90473f36.png)
