### PR TITLE
Fixed an issue where `Flight::request()->base` would display only a yen symbol in Windows environments without a parent directory

### DIFF
--- a/flight/net/Request.php
+++ b/flight/net/Request.php
@@ -173,6 +173,9 @@ class Request
                 $base = str_replace(['\\', ' '], ['/', '%20'], $base);
             }
             $base = dirname($base);
+            if ($base === '\\') {
+                $base = '/';
+            }
             $config = [
                 'url'        => $url,
                 'base'       => $base,


### PR DESCRIPTION
In Windows environments, when `$_SERVER['SCRIPT_NAME']` is a filename without a parent directory, such as `/index.php`, `Flight::request()->base` returns only a yen symbol. This issue will be fixed.

\* As this is my first pull request to this repository, I would appreciate it if you could point out any issues.
