### PR TITLE
Update RouteCommand.php

### DIFF
--- a/flight/commands/RouteCommand.php
+++ b/flight/commands/RouteCommand.php
@@ -65,7 +65,11 @@ class RouteCommand extends AbstractBaseCommand
                 if (!empty($route->middleware)) {
                     try {
                         $middlewares = array_map(function ($middleware) {
-                            $middleware_class_name = explode("\\", get_class($middleware));
+                            if (is_string($middleware)) {
+                                $middleware_class_name = explode("\\", $middleware);
+                            } else {
+                                $middleware_class_name = explode("\\", get_class($middleware));
+                            }
                             return preg_match("/^class@anonymous/", end($middleware_class_name)) ? 'Anonymous' : end($middleware_class_name);
                         }, $route->middleware);
                     } catch (\TypeError $e) {

--- a/tests/commands/RouteCommandTest.php
+++ b/tests/commands/RouteCommandTest.php
@@ -113,7 +113,7 @@ PHP;
         | /post   | POST, OPTIONS      |       | No       | Closure        |
         | /delete | DELETE, OPTIONS    |       | No       | -              |
         | /put    | PUT, OPTIONS       |       | No       | -              |
-        | /patch  | PATCH, OPTIONS     |       | No       | Bad Middleware |
+        | /patch  | PATCH, OPTIONS     |       | No       | SomeMiddleware |
         +---------+--------------------+-------+----------+----------------+
         output; // phpcs:ignore
 


### PR DESCRIPTION
fix return `Bad Middleware` when using class string name in router.

```php
$router->group('', function(Router $router) use ($app) {

	$router->get('/', function() use ($app) {
		$app->render('welcome', ['message' => 'some message...']);
	});
}, [ SecurityHeadersMiddleware::class ]);
```

then run `php runway routes` in terminal.

before fix:

```bash
Routes
+----------------------------------------------+--------------------+-------+----------+----------------+
| Pattern                                      | Methods            | Alias | Streamed | Middleware     |
+----------------------------------------------+--------------------+-------+----------+----------------+
| /                                            | GET, HEAD, OPTIONS |       | No       | Bad Middleware |
```

after fix:

```bash
+----------------------------------------------+--------------------+-------+----------+------------------------------------------------+
| Pattern                                      | Methods            | Alias | Streamed | Middleware                                     |
+----------------------------------------------+--------------------+-------+----------+------------------------------------------------+
| /                                            | GET, HEAD, OPTIONS |       | No       | SecurityHeadersMiddleware                      |
```