### PR TITLE
fix  index_root  or app_root not set in .runway-config.json error

### DIFF
--- a/flight/commands/ControllerCommand.php
+++ b/flight/commands/ControllerCommand.php
@@ -29,7 +29,7 @@ class ControllerCommand extends AbstractBaseCommand
     public function execute(string $controller)
     {
         $io = $this->app()->io();
-        if (isset($this->config['app_root']) === false) {
+        if (isset($this->config['runway']['app_root']) === false) {
             $io->error('app_root not set in .runway-config.json', true);
             return;
         }
@@ -38,7 +38,7 @@ class ControllerCommand extends AbstractBaseCommand
             $controller .= 'Controller';
         }
 
-        $controllerPath = getcwd() . DIRECTORY_SEPARATOR . $this->config['app_root'] . 'controllers' . DIRECTORY_SEPARATOR . $controller . '.php';
+        $controllerPath = getcwd() . DIRECTORY_SEPARATOR . $this->config['runway']['app_root'] . 'controllers' . DIRECTORY_SEPARATOR . $controller . '.php';
         if (file_exists($controllerPath) === true) {
             $io->error($controller . ' already exists.', true);
             return;
@@ -86,6 +86,6 @@ class ControllerCommand extends AbstractBaseCommand
     protected function persistClass(string $controllerName, PhpFile $file)
     {
         $printer = new \Nette\PhpGenerator\PsrPrinter();
-        file_put_contents(getcwd() . DIRECTORY_SEPARATOR . $this->config['app_root'] . 'controllers' . DIRECTORY_SEPARATOR . $controllerName . '.php', $printer->printFile($file));
+        file_put_contents(getcwd() . DIRECTORY_SEPARATOR . $this->config['runway']['app_root'] . 'controllers' . DIRECTORY_SEPARATOR . $controllerName . '.php', $printer->printFile($file));
     }
 }

--- a/flight/commands/RouteCommand.php
+++ b/flight/commands/RouteCommand.php
@@ -41,7 +41,8 @@ class RouteCommand extends AbstractBaseCommand
     {
         $io = $this->app()->io();
 
-        if (isset($this->config['index_root']) === false) {
+        
+        if (isset($this->config['runway']['index_root']) === false) {
             $io->error('index_root not set in .runway-config.json', true);
             return;
         }
@@ -50,7 +51,7 @@ class RouteCommand extends AbstractBaseCommand
 
         $cwd = getcwd();
 
-        $index_root = $cwd . '/' . $this->config['index_root'];
+        $index_root = $cwd . '/' . $this->config['runway']['index_root'];
 
         // This makes it so the framework doesn't actually execute
         Flight::map('start', function () {

--- a/tests/commands/ControllerCommandTest.php
+++ b/tests/commands/ControllerCommandTest.php
@@ -67,7 +67,7 @@ class ControllerCommandTest extends TestCase
         $app = $this->newApp('test', '0.0.1');
         mkdir(__DIR__ . '/controllers/');
         file_put_contents(__DIR__ . '/controllers/TestController.php', '<?php class TestController {}');
-        $app->add(new ControllerCommand(['subway' => ['app_root' => 'tests/commands/']]));
+        $app->add(new ControllerCommand(['runway' => ['app_root' => 'tests/commands/']]));
         $app->handle(['runway', 'make:controller', 'Test']);
 
         $this->assertStringContainsString('TestController already exists.', file_get_contents(static::$ou));
@@ -76,7 +76,7 @@ class ControllerCommandTest extends TestCase
     public function testCreateController(): void
     {
         $app = $this->newApp('test', '0.0.1');
-        $app->add(new ControllerCommand(['subway' => ['app_root' => 'tests/commands/']]));
+        $app->add(new ControllerCommand(['runway' => ['app_root' => 'tests/commands/']]));
         $app->handle(['runway', 'make:controller', 'Test']);
 
         $this->assertFileExists(__DIR__ . '/controllers/TestController.php');

--- a/tests/commands/ControllerCommandTest.php
+++ b/tests/commands/ControllerCommandTest.php
@@ -67,7 +67,7 @@ class ControllerCommandTest extends TestCase
         $app = $this->newApp('test', '0.0.1');
         mkdir(__DIR__ . '/controllers/');
         file_put_contents(__DIR__ . '/controllers/TestController.php', '<?php class TestController {}');
-        $app->add(new ControllerCommand(['app_root' => 'tests/commands/']));
+        $app->add(new ControllerCommand(['subway' => ['app_root' => 'tests/commands/']]));
         $app->handle(['runway', 'make:controller', 'Test']);
 
         $this->assertStringContainsString('TestController already exists.', file_get_contents(static::$ou));
@@ -76,7 +76,7 @@ class ControllerCommandTest extends TestCase
     public function testCreateController(): void
     {
         $app = $this->newApp('test', '0.0.1');
-        $app->add(new ControllerCommand(['app_root' => 'tests/commands/']));
+        $app->add(new ControllerCommand(['subway' => ['app_root' => 'tests/commands/']]));
         $app->handle(['runway', 'make:controller', 'Test']);
 
         $this->assertFileExists(__DIR__ . '/controllers/TestController.php');

--- a/tests/commands/RouteCommandTest.php
+++ b/tests/commands/RouteCommandTest.php
@@ -101,7 +101,7 @@ PHP;
     {
         $app = @$this->newApp('test', '0.0.1');
         $this->createIndexFile();
-        $app->add(new RouteCommand(['subway' => ['index_root' => 'tests/commands/index.php']]));
+        $app->add(new RouteCommand(['runway' => ['index_root' => 'tests/commands/index.php']]));
         @$app->handle(['runway', 'routes']);
 
         $this->assertStringContainsString('Routes', file_get_contents(static::$ou));

--- a/tests/commands/RouteCommandTest.php
+++ b/tests/commands/RouteCommandTest.php
@@ -101,7 +101,7 @@ PHP;
     {
         $app = @$this->newApp('test', '0.0.1');
         $this->createIndexFile();
-        $app->add(new RouteCommand(['index_root' => 'tests/commands/index.php']));
+        $app->add(new RouteCommand(['subway' => ['index_root' => 'tests/commands/index.php']]));
         @$app->handle(['runway', 'routes']);
 
         $this->assertStringContainsString('Routes', file_get_contents(static::$ou));
@@ -127,7 +127,7 @@ PHP;
     {
         $app = @$this->newApp('test', '0.0.1');
         $this->createIndexFile();
-        $app->add(new RouteCommand(['index_root' => 'tests/commands/index.php']));
+        $app->add(new RouteCommand(['runway' => ['index_root' => 'tests/commands/index.php']]));
         @$app->handle(['runway', 'routes', '--post']);
 
         $this->assertStringContainsString('Routes', file_get_contents(static::$ou));


### PR DESCRIPTION

![f0123faf-c6ac-4e20-a18f-e04389fc4ee1](https://github.com/user-attachments/assets/2582d71d-01d5-4f2f-afa3-83c26e66ec3a)


The `app_root` and `index_root` values are now located in `$config['runway']` .

