### PR TITLE
Ignore LiMIT when using RETURNING

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ clover.xml
 phpcs.xml
 .runway-config.json
 .runway-creds.json
+.DS_Store

--- a/flight/database/SimplePdo.php
+++ b/flight/database/SimplePdo.php
@@ -68,7 +68,7 @@ class SimplePdo extends PdoWrapper
     public function fetchRow(string $sql, array $params = []): ?Collection
     {
         // Smart LIMIT 1 addition (avoid if already present at end or complex query)
-        if (!preg_match('/\sLIMIT\s+\d+(?:\s+OFFSET\s+\d+)?\s*$/i', trim($sql))) {
+        if (!preg_match('/\s(LIMIT\s+\d+(?:\s+OFFSET\s+\d+)?|RETURNING\s+.+)\s*$/i', trim($sql))) {
             $sql .= ' LIMIT 1';
         }
 

--- a/tests/SimplePdoTest.php
+++ b/tests/SimplePdoTest.php
@@ -153,6 +153,17 @@ class SimplePdoTest extends TestCase
         $this->assertInstanceOf(Collection::class, $row);
         $this->assertEquals(3, $row['id']); // Should be Bob (id=3)
     }
+    
+    public function testFetchRowDoesNotAddLimitAfterReturningClause(): void
+    {
+        $row = $this->db->fetchRow(
+            'INSERT INTO users (name, email) VALUES (?, ?) RETURNING id, name',
+            ['Alice', 'alice@example.com']
+        );
+
+        $this->assertInstanceOf(Collection::class, $row);
+        $this->assertSame('Alice', $row['name']);
+    }
 
     // =========================================================================
     // fetchAll Tests


### PR DESCRIPTION
Using fetchRow with RETURNING creates invalid SQL. Ignoring LIMIT will fix this issue. 